### PR TITLE
Explicit file protocol for Safari

### DIFF
--- a/foxplot/write_tmpfile.py
+++ b/foxplot/write_tmpfile.py
@@ -39,5 +39,5 @@ def write_tmpfile(html: str) -> str:
         delete=False,
     ) as output_file:
         output_file.write(html)
-        filename = output_file.name
+        filename = f'file://{output_file.name}'
     return filename

--- a/foxplot/write_tmpfile.py
+++ b/foxplot/write_tmpfile.py
@@ -39,5 +39,5 @@ def write_tmpfile(html: str) -> str:
         delete=False,
     ) as output_file:
         output_file.write(html)
-        filename = f'file://{output_file.name}'
+        filename = f"file://{output_file.name}"
     return filename


### PR DESCRIPTION
On my computer, `webbrowser` cannot launch Safari unless the path conforms to the [file URI scheme](https://en.wikipedia.org/wiki/File_URI_scheme) with the `file://` prefix:

https://github.com/stephane-caron/foxplot/blob/d0feca993cb10a4433877e505c5a7b5f74978ad0/foxplot/fox.py#L118

I believe this fix would not break `foxplot` for any other OS/browser, but I haven't verified it.