### PR TITLE
[fix] consistent labels

### DIFF
--- a/foxplot/generate_html.py
+++ b/foxplot/generate_html.py
@@ -88,7 +88,7 @@ def generate_html(
     right_axis_label = f" {right_axis_unit}" if right_axis_unit else ""
     left_labels = list(left_axis.keys())
     right_labels = list(right_axis.keys())
-    labels = left_labels + right_labels
+    labels = left_labels + [r for r in right_labels if r not in left_labels]
     series_from_label = {}
     series_from_label.update(left_axis)
     series_from_label.update(right_axis)

--- a/foxplot/generate_html.py
+++ b/foxplot/generate_html.py
@@ -86,9 +86,9 @@ def generate_html(
     color_picker = ColorPicker()
     left_axis_label = f" {left_axis_unit}" if left_axis_unit else ""
     right_axis_label = f" {right_axis_unit}" if right_axis_unit else ""
-    left_labels = left_axis.keys()
-    right_labels = right_axis.keys()
-    labels = (left_axis | right_axis).keys()
+    left_labels = list(left_axis.keys())
+    right_labels = list(right_axis.keys())
+    labels = left_labels + right_labels
     series_from_label = {}
     series_from_label.update(left_axis)
     series_from_label.update(right_axis)

--- a/foxplot/generate_html.py
+++ b/foxplot/generate_html.py
@@ -86,9 +86,9 @@ def generate_html(
     color_picker = ColorPicker()
     left_axis_label = f" {left_axis_unit}" if left_axis_unit else ""
     right_axis_label = f" {right_axis_unit}" if right_axis_unit else ""
-    left_labels = list(left_axis.keys())
-    right_labels = list(right_axis.keys())
-    labels = left_labels + right_labels
+    left_labels = left_axis.keys()
+    right_labels = right_axis.keys()
+    labels = (left_axis | right_axis).keys()
     series_from_label = {}
     series_from_label.update(left_axis)
     series_from_label.update(right_axis)

--- a/foxplot/generate_html.py
+++ b/foxplot/generate_html.py
@@ -86,9 +86,9 @@ def generate_html(
     color_picker = ColorPicker()
     left_axis_label = f" {left_axis_unit}" if left_axis_unit else ""
     right_axis_label = f" {right_axis_unit}" if right_axis_unit else ""
-    left_labels = left_axis.keys()
-    right_labels = right_axis.keys()
-    labels = left_labels | right_labels
+    left_labels = list(left_axis.keys())
+    right_labels = list(right_axis.keys())
+    labels = left_labels + right_labels
     series_from_label = {}
     series_from_label.update(left_axis)
     series_from_label.update(right_axis)


### PR DESCRIPTION
It missed my attention that the earlier fix was not enough when I start separate interactive sessions.

The `|` operator on two `dict_keys` returns an unordered `set`, so it's better to use lists.